### PR TITLE
fix missing files from installed headers

### DIFF
--- a/src/base/base.pri
+++ b/src/base/base.pri
@@ -36,17 +36,16 @@ INSTALL_HEADERS += \
     base/QXmppUtils.h \
     base/QXmppVCardIq.h \
     base/QXmppVersionIq.h \
-    base/QXmppGaming.h
+    base/QXmppGaming.h \
+    base/QXmppMessageCarbonsIq.h \
+    base/QXmppReachAddress.h \
+    base/QXmppSimpleArchivePreferenceIq.h \
+    base/QXmppStreamManagement.h
 
 HEADERS += \
     base/QXmppCodec_p.h \
     base/QXmppSasl_p.h \
-    base/QXmppStreamInitiationIq_p.h \
-    base/QXmppSimpleArchivePreferenceIq.h \
-    base/QXmppMessageCarbonsIq.h \
-    base/QXmppReachAddress.h \
-    base/QXmppStreamManagement.h \
-    base/QXmppGaming.h
+    base/QXmppStreamInitiationIq_p.h
 
 # Source files
 SOURCES += \


### PR DESCRIPTION
I am also getting some issues building this on qt5.4 linux it build fine with this patch on qt4, here is the buil log.

```
base/QXmppMessage.cpp:94:34: error: field ‘forwarded’ has incomplete type ‘QSharedPointer<QXmppMessage>’
     QSharedPointer<QXmppMessage> forwarded;
                                  ^
base/QXmppMessage.cpp:97:34: error: field ‘mamMessage’ has incomplete type ‘QSharedPointer<QXmppMessage>’
     QSharedPointer<QXmppMessage> mamMessage;
                                  ^
base/QXmppMessage.cpp:100:34: error: field ‘carbonMessage’ has incomplete type ‘QSharedPointer<QXmppMessage>’
     QSharedPointer<QXmppMessage> carbonMessage;
                                  ^
base/QXmppMessage.cpp: In member function ‘void QXmppMessage::setForwarded(const QXmppMessage&)’:
base/QXmppMessage.cpp:424:76: error: invalid use of incomplete type ‘class QSharedPointer<QXmppMessage>’
     d->forwarded = QSharedPointer<QXmppMessage>(new QXmppMessage(forwarded));
                                                                            ^
In file included from /usr/include/qt/QtCore/qobject.h:48:0,
                 from /usr/include/qt/QtCore/qiodevice.h:39,
                 from /usr/include/qt/QtCore/qtextstream.h:37,
                 from /usr/include/qt/QtCore/QTextStream:1,
                 from base/QXmppMessage.cpp:26:
/usr/include/qt/QtCore/qmetatype.h:1292:1: error: declaration of ‘class QSharedPointer<QXmppMessage>’
 QT_FOR_EACH_AUTOMATIC_TEMPLATE_SMART_POINTER(QT_FORWARD_DECLARE_SHARED_POINTER_TYPES_ITER)
 ^
base/QXmppMessage.cpp: In member function ‘void QXmppMessage::setMaMMessage(const QXmppMessage&)’:
base/QXmppMessage.cpp:444:75: error: invalid use of incomplete type ‘class QSharedPointer<QXmppMessage>’
     d->mamMessage = QSharedPointer<QXmppMessage>(new QXmppMessage(message));
                                                                           ^
In file included from /usr/include/qt/QtCore/qobject.h:48:0,
                 from /usr/include/qt/QtCore/qiodevice.h:39,
                 from /usr/include/qt/QtCore/qtextstream.h:37,
                 from /usr/include/qt/QtCore/QTextStream:1,
                 from base/QXmppMessage.cpp:26:
/usr/include/qt/QtCore/qmetatype.h:1292:1: error: declaration of ‘class QSharedPointer<QXmppMessage>’
 QT_FOR_EACH_AUTOMATIC_TEMPLATE_SMART_POINTER(QT_FORWARD_DECLARE_SHARED_POINTER_TYPES_ITER)
 ^
base/QXmppMessage.cpp: In member function ‘void QXmppMessage::setMessagecarbon(const QXmppMessage&)’:
base/QXmppMessage.cpp:906:78: error: invalid use of incomplete type ‘class QSharedPointer<QXmppMessage>’
     d->carbonMessage = QSharedPointer<QXmppMessage>(new QXmppMessage(message));
                                                                              ^
In file included from /usr/include/qt/QtCore/qobject.h:48:0,
                 from /usr/include/qt/QtCore/qiodevice.h:39,
                 from /usr/include/qt/QtCore/qtextstream.h:37,
                 from /usr/include/qt/QtCore/QTextStream:1,
                 from base/QXmppMessage.cpp:26:
/usr/include/qt/QtCore/qmetatype.h:1292:1: error: declaration of ‘class QSharedPointer<QXmppMessage>’
 QT_FOR_EACH_AUTOMATIC_TEMPLATE_SMART_POINTER(QT_FORWARD_DECLARE_SHARED_POINTER_TYPES_ITER)
 ^
base/QXmppMessage.cpp: In member function ‘bool QXmppMessage::hasForwarded() const’:
base/QXmppMessage.cpp:410:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
base/QXmppMessage.cpp: In member function ‘QXmppMessage QXmppMessage::forwarded() const’:
base/QXmppMessage.cpp:419:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
base/QXmppMessage.cpp: In member function ‘bool QXmppMessage::hasMaMMessage() const’:
base/QXmppMessage.cpp:430:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
base/QXmppMessage.cpp: In member function ‘QXmppMessage QXmppMessage::mamMessage() const’:
base/QXmppMessage.cpp:439:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
base/QXmppMessage.cpp: In member function ‘bool QXmppMessage::hasMessageCarbon() const’:
base/QXmppMessage.cpp:891:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
base/QXmppMessage.cpp: In member function ‘QXmppMessage QXmppMessage::carbonMessage() const’:
base/QXmppMessage.cpp:901:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
Makefile:1557: recipe for target 'QXmppMessage.o' failed
make[1]: *** [QXmppMessage.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/home/ricardo/code/build/qxmpp-qt5-git/src/qxmpp/src'
Makefile:42: recipe for target 'sub-src-make_first-ordered' failed
make: *** [sub-src-make_first-ordered] Error 2
```

Sorry for the issue/pull request but the issues are not enabled :/